### PR TITLE
Android: fix swiping

### DIFF
--- a/Slideshow.js
+++ b/Slideshow.js
@@ -186,6 +186,7 @@ export default class Slideshow extends Component {
           horizontal={true}
           showsHorizontalScrollIndicator={false}
           scrollEnabled={this.props.scrollEnabled}
+          pagingEnabled={true}
           {...this._panResponder.panHandlers}
           style={[
             styles.container, 

--- a/Slideshow.js
+++ b/Slideshow.js
@@ -166,6 +166,14 @@ export default class Slideshow extends Component {
     }, 16);
   }
 
+  onScrollEvent = (e) => {
+    // Change the indicator on android when swiping
+    let contentOffset = e.nativeEvent.contentOffset;
+    let viewSize = e.nativeEvent.layoutMeasurement;
+    let pageNum = Math.floor(contentOffset.x / viewSize.width);
+    this.setState({position: pageNum});
+  }
+
   componentWillUnmount() {
     clearInterval(this._interval);
   }
@@ -187,6 +195,8 @@ export default class Slideshow extends Component {
           showsHorizontalScrollIndicator={false}
           scrollEnabled={this.props.scrollEnabled}
           pagingEnabled={true}
+          onScrollEndDrag={this.onScrollEvent}
+          onMomentumScrollEnd={this.onScrollEvent}
           {...this._panResponder.panHandlers}
           style={[
             styles.container, 


### PR DESCRIPTION
1. Enable paging on the scrollview to make sure swiping on Android moves image by image (currently it scrolls continuously, resulting in stopping mid-image)
2. Update page indicator when swiping on Android (currently it doesn't update at all when swiping)

Fixes #haqiqiw/react-native-slideshow/issues/9 (a bug in the original library), using the solution provided in that issue.